### PR TITLE
Tweak files and dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+  test.warning = false
+end
+
+task :default => :test

--- a/fluent-plugin-elasticsearch-timestamp-check.gemspec
+++ b/fluent-plugin-elasticsearch-timestamp-check.gemspec
@@ -13,5 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
+  spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "bundler", "~> 1.3"
 end


### PR DESCRIPTION
Hi, this is neat plugin to use ES plugin together.
I've found some improvements:

* Specify gem dependencies explicitly
  * `Fluent::Plugin::Filter` should work with Fluentd v0.14. So, we should specify this version constraints in gemspec
* 'bundler/gem_tasks' in Rakefile makes to be able to execute `bundle exec rake release` which is convenient task for releasing gem
* Gemfile which is used by bundler