### PR TITLE
Add testcases

### DIFF
--- a/fluent-plugin-elasticsearch-timestamp-check.gemspec
+++ b/fluent-plugin-elasticsearch-timestamp-check.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "test-unit", "~> 3.2"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,8 @@
+require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
+require 'fluent/plugin/filter_elasticsearch_timestamp_check'
+
+class Test::Unit::TestCase
+  include Fluent::Test::Helpers
+end

--- a/test/plugin/test_filter_elasticsearch_timestamp_check.rb
+++ b/test/plugin/test_filter_elasticsearch_timestamp_check.rb
@@ -1,0 +1,60 @@
+require 'helper'
+
+class TestElasticsearchTimestampCheckFilter < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf='')
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::ElasticsearchTimestampCheckFilter).configure(conf)
+  end
+
+  def test_added_timestamp
+    d = create_driver
+    d.run(default_tag: 'test') do
+      d.feed({'test' => 'notime'})
+    end
+    filtered = d.filtered.map {|e| e.last}.first
+    assert_true(filtered.key?("@timestamp"))
+    assert_true(filtered.key?("fluent_added_timestamp"))
+  end
+
+  data('@timestamp'       => '@timestamp',
+       'timestamp'        => 'timestamp',
+       'time'             => 'time',
+       'syslog_timestamp' => 'syslog_timestamp')
+  def test_timestamp_with_normal(data)
+    timekey = data
+    d = create_driver
+    timestamp = '2017-09-19T14:40:08.321+0900'
+    d.run(default_tag: 'test') do
+      d.feed({'test' => 'notime'}.merge(timekey => timestamp))
+    end
+    filtered = d.filtered.map{|e| e.last}.first
+    assert_true(filtered.key?("@timestamp"))
+    assert_true(filtered.key?("fluent_converted_timestamp"))
+    assert_equal(timestamp, filtered["fluent_converted_timestamp"])
+  end
+
+  data('@timestamp'       => '@timestamp',
+       'timestamp'        => 'timestamp',
+       'time'             => 'time',
+       'syslog_timestamp' => 'syslog_timestamp')
+  def test_timestamp_with_digit(data)
+    timekey = data
+    d = create_driver
+    timestamp = '1505800348899'
+    d.run(default_tag: 'test') do
+      d.feed({'test' => 'notime'}.merge(timekey => timestamp))
+    end
+    filtered = d.filtered.map{|e| e.last}.first
+    num = timestamp.to_i
+    formatted_time = Time.at(
+      num / (10 ** ((Math.log10(num).to_i + 1) - 10))
+    ).strftime('%Y-%m-%dT%H:%M:%S.%L%z')
+    assert_true(filtered.key?("@timestamp"))
+    assert_true(filtered.key?("fluent_converted_timestamp"))
+    assert_equal(formatted_time, filtered["fluent_converted_timestamp"])
+  end
+
+end


### PR DESCRIPTION
Please review after merging #5.

---

I've added test cases for adding `@timestamp` in records.

And I have a question for epoch millis converting specification.
Currently, this routine always drops milliseconds precision time.
Is it intentional?

A fixing idea (Using `#to_f` and determine digit number with log10):

```diff
diff --git a/lib/fluent/plugin/filter_elasticsearch_timestamp_check.rb b/lib/fl
uent/plugin/filter_elasticsearch_timestamp_check.rb
index 58fc9a5..c2c2254 100644
--- a/lib/fluent/plugin/filter_elasticsearch_timestamp_check.rb
+++ b/lib/fluent/plugin/filter_elasticsearch_timestamp_check.rb
@@ -24,14 +24,14 @@ module Fluent::Plugin
         begin
           # all digit entry would be treated as epoch seconds or epoch millis
           if !!(timestamp =~ /\A[-+]?\d+\z/)
-            num = timestamp.to_i
+            num = timestamp.to_f
             # epoch second or epoch millis should be either 10 or 13 digits
             # other length should be considered invalid (until the next digit
             # rollover at 2286-11-20  17:46:40 Z
-            next unless [10, 13].include?(num.to_s.length)
+            next unless [10, 13].include?(Math.log10(num).to_i + 1)
             record['@timestamp'] = record['fluent_converted_timestamp'] =
               Time.at(
-                num / (10 ** (num.to_s.length - 10))
+                num / (10 ** ((Math.log10(num).to_i + 1) - 10))
               ).strftime('%Y-%m-%dT%H:%M:%S.%L%z')
             break
           end 
```