### PR TITLE
Handle milliseconds in time formatting

### DIFF
--- a/lib/fluent/plugin/filter_elasticsearch_timestamp_check.rb
+++ b/lib/fluent/plugin/filter_elasticsearch_timestamp_check.rb
@@ -24,14 +24,14 @@ module Fluent::Plugin
         begin
           # all digit entry would be treated as epoch seconds or epoch millis
           if !!(timestamp =~ /\A[-+]?\d+\z/)
-            num = timestamp.to_i
+            num = timestamp.to_f
             # epoch second or epoch millis should be either 10 or 13 digits
             # other length should be considered invalid (until the next digit
             # rollover at 2286-11-20  17:46:40 Z
-            next unless [10, 13].include?(num.to_s.length)
+            next unless [10, 13].include?(Math.log10(num).to_i + 1)
             record['@timestamp'] = record['fluent_converted_timestamp'] =
               Time.at(
-                num / (10 ** (num.to_s.length - 10))
+                num / (10 ** ((Math.log10(num).to_i + 1) - 10))
               ).strftime('%Y-%m-%dT%H:%M:%S.%L%z')
             break
           end

--- a/test/plugin/test_filter_elasticsearch_timestamp_check.rb
+++ b/test/plugin/test_filter_elasticsearch_timestamp_check.rb
@@ -48,7 +48,7 @@ class TestElasticsearchTimestampCheckFilter < Test::Unit::TestCase
       d.feed({'test' => 'notime'}.merge(timekey => timestamp))
     end
     filtered = d.filtered.map{|e| e.last}.first
-    num = timestamp.to_i
+    num = timestamp.to_f
     formatted_time = Time.at(
       num / (10 ** ((Math.log10(num).to_i + 1) - 10))
     ).strftime('%Y-%m-%dT%H:%M:%S.%L%z')


### PR DESCRIPTION
Calculation for digits of floating point number should handle with `Math.log10` instead of `#to_s.length`.

Because old forward protocol does not include nanosecond precision time.
So, it had been correct for v0.12 protocol.

Now, v0.14 forward protocol includes nanosecond precision time with `EventTime` ext type.
Thus, this is unintentional result in new forward protocol for v0.14.