### PR TITLE
Validate arbitrary digits timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ elasticsearch.
 `subsecond_precision` controls the subsecond precision during the conversion.
 Default value is set to `3` (millisecond).
 
+Other `subsecond_precision` sample values are:
+
+* `6` (microsecond)
+* `9` (nanosecond)
+* `12` (picosecond)
+
+and more high precision is also supported.
+
 ## Usage
 
 ```

--- a/test/plugin/test_filter_elasticsearch_timestamp_check.rb
+++ b/test/plugin/test_filter_elasticsearch_timestamp_check.rb
@@ -77,7 +77,7 @@ class TestElasticsearchTimestampCheckFilter < Test::Unit::TestCase
     timekey = data
     precision = 9
     d = create_driver(%[subsecond_precision #{precision}])
-    timestamp = '1505800348899'
+    timestamp = '1517878172013770000'
     d.run(default_tag: 'test') do
       d.feed({'test' => 'notime'}.merge(timekey => timestamp))
     end
@@ -86,6 +86,7 @@ class TestElasticsearchTimestampCheckFilter < Test::Unit::TestCase
     formatted_time = Time.at(
       num / (10 ** ((Math.log10(num).to_i + 1) - 10))
     ).strftime("%Y-%m-%dT%H:%M:%S.%#{precision}N%z")
+    assert_equal([10, 13, 10 + precision], d.instance.timestamp_digits)
     assert_true(filtered.key?("@timestamp"))
     assert_true(filtered.key?("fluent_converted_timestamp"))
     assert_equal(formatted_time, filtered["fluent_converted_timestamp"])

--- a/test/plugin/test_filter_elasticsearch_timestamp_check.rb
+++ b/test/plugin/test_filter_elasticsearch_timestamp_check.rb
@@ -64,6 +64,30 @@ class TestElasticsearchTimestampCheckFilter < Test::Unit::TestCase
     formatted_time = Time.at(
       num / (10 ** ((Math.log10(num).to_i + 1) - 10))
     ).strftime('%Y-%m-%dT%H:%M:%S.%3N%z')
+    assert_equal([10, 13], d.instance.timestamp_digits)
+    assert_true(filtered.key?("@timestamp"))
+    assert_true(filtered.key?("fluent_converted_timestamp"))
+    assert_equal(formatted_time, filtered["fluent_converted_timestamp"])
+  end
+
+  data('@timestamp'       => '@timestamp',
+       'timestamp'        => 'timestamp',
+       'time'             => 'time',
+       'syslog_timestamp' => 'syslog_timestamp')
+  def test_timestamp_with_digit_and_micro_precision(data)
+    timekey = data
+    precision = 6
+    d = create_driver(%[subsecond_precision #{precision}])
+    timestamp = '1517878172013770'
+    d.run(default_tag: 'test') do
+      d.feed({'test' => 'notime'}.merge(timekey => timestamp))
+    end
+    filtered = d.filtered.map{|e| e.last}.first
+    num = timestamp.to_f
+    formatted_time = Time.at(
+      num / (10 ** ((Math.log10(num).to_i + 1) - 10))
+    ).strftime("%Y-%m-%dT%H:%M:%S.%#{precision}N%z")
+    assert_equal([10, 13, 10 + precision], d.instance.timestamp_digits)
     assert_true(filtered.key?("@timestamp"))
     assert_true(filtered.key?("fluent_converted_timestamp"))
     assert_equal(formatted_time, filtered["fluent_converted_timestamp"])


### PR DESCRIPTION
Sorry, previous PR seems not to work as expected. :cry:

Follows up #10.

Due to https://github.com/ecwws/fluent-plugin-elasticsearch-timestamp-check/pull/10#issuecomment-363173462.